### PR TITLE
ft: add form input field component #36

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,16 +17,19 @@
     ]
   },
   "dependencies": {
-    "@reduxjs/toolkit": "^1.9.5",
+    "@hookform/resolvers": "^3.1.0",
+    "@reduxjs/toolkit": "^1.9.3",
     "clsx": "^1.2.1",
     "query-string": "^8.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.43.9",
     "react-icons": "^4.8.0",
     "react-redux": "^8.0.5",
     "react-router-dom": "6.9.0",
     "redux": "^4.2.1",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@babel/core": "^7.21.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,11 @@
 lockfileVersion: '6.0'
 
 dependencies:
+  '@hookform/resolvers':
+    specifier: ^3.1.0
+    version: 3.1.0(react-hook-form@7.43.9)
   '@reduxjs/toolkit':
-    specifier: ^1.9.5
+    specifier: ^1.9.3
     version: 1.9.5(react-redux@8.0.5)(react@18.2.0)
   clsx:
     specifier: ^1.2.1
@@ -16,6 +19,9 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
+  react-hook-form:
+    specifier: ^7.43.9
+    version: 7.43.9(react@18.2.0)
   react-icons:
     specifier: ^4.8.0
     version: 4.8.0(react@18.2.0)
@@ -31,6 +37,9 @@ dependencies:
   uuid:
     specifier: ^9.0.0
     version: 9.0.0
+  zod:
+    specifier: ^3.21.4
+    version: 3.21.4
 
 devDependencies:
   '@babel/core':
@@ -2027,6 +2036,14 @@ packages:
   /@fal-works/esbuild-plugin-global-externals@2.1.2:
     resolution: {integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==}
     dev: true
+
+  /@hookform/resolvers@3.1.0(react-hook-form@7.43.9):
+    resolution: {integrity: sha512-z0A8K+Nxq+f83Whm/ajlwE6VtQlp/yPHZnXw7XWVPIGm1Vx0QV8KThU3BpbBRfAZ7/dYqCKKBNnQh85BkmBKkA==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
+    dependencies:
+      react-hook-form: 7.43.9(react@18.2.0)
+    dev: false
 
   /@humanwhocodes/config-array@0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
@@ -10600,6 +10617,15 @@ packages:
       react-is: 18.1.0
     dev: true
 
+  /react-hook-form@7.43.9(react@18.2.0):
+    resolution: {integrity: sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /react-icons@4.8.0(react@18.2.0):
     resolution: {integrity: sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==}
     peerDependencies:
@@ -12776,3 +12802,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zod@3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+    dev: false

--- a/src/components/form/FormInput.tsx
+++ b/src/components/form/FormInput.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export const FormInput = () => {
-  return <div>FormInput</div>;
-};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,6 +6,7 @@ import { Counter } from './inputs/Counter';
 import { Sidebar } from './sidebar/SideBar';
 import { Modal } from './shared/modals/Modal';
 import { Heading } from './Heading';
+import { InputField } from './inputs/InputField';
 
 export {
   Footer,
@@ -16,4 +17,5 @@ export {
   Modal,
   Heading,
   Sidebar,
+  InputField,
 };

--- a/src/components/inputs/Demo.tsx
+++ b/src/components/inputs/Demo.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { BsFillLockFill } from 'react-icons/bs';
+import { MdEmail } from 'react-icons/md';
+import { InputField } from './InputField';
+import { Button } from '../shared';
+import { TLoginFieldValues, loginSchema } from '../../utils/schemas';
+
+export function Demo() {
+  const [isLoading, setIsLoading] = React.useState(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<TLoginFieldValues>({
+    resolver: zodResolver(loginSchema),
+  });
+
+  const onSubmit: SubmitHandler<TLoginFieldValues> = (
+    data: TLoginFieldValues,
+  ) => {
+    setIsLoading(true);
+    console.log(data);
+    setIsLoading(false);
+    reset();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div className="grid gap-5">
+        <InputField<TLoginFieldValues>
+          id="email"
+          label="Email"
+          type="email"
+          disabled={isLoading}
+          register={register}
+          errors={errors}
+          icon={MdEmail}
+          required
+        />
+
+        <InputField<TLoginFieldValues>
+          id="password"
+          label="Password"
+          type="password"
+          disabled={isLoading}
+          register={register}
+          errors={errors}
+          icon={BsFillLockFill}
+          required
+        />
+      </div>
+      <div className="col-span-1">
+        <Button
+          isSubmit
+          disabled={isLoading}
+          colorScheme="btn-secondary"
+          label="Login"
+        />
+      </div>
+    </form>
+  );
+}

--- a/src/components/inputs/Demo2.tsx
+++ b/src/components/inputs/Demo2.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  BiMoney, BiPackage, BiPaperPlane, BiPencil,
+} from 'react-icons/bi';
+import { InputField } from './InputField';
+import { Button } from '../shared';
+import {
+  TCreateProductFieldValues,
+  createProductSchema,
+} from '../../utils/schemas';
+
+export function Demo2() {
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<TCreateProductFieldValues>({
+    resolver: zodResolver(createProductSchema),
+  });
+
+  const onSubmit: SubmitHandler<TCreateProductFieldValues> = (
+    data: TCreateProductFieldValues,
+  ) => {
+    setIsLoading(true);
+    console.log(data);
+    setIsLoading(false);
+    reset();
+  };
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div className="grid gap-5">
+        <InputField<TCreateProductFieldValues>
+          id="name"
+          label="Name"
+          type="text"
+          disabled={isLoading}
+          register={register}
+          errors={errors}
+          icon={BiPencil}
+          required
+        />
+
+        <InputField<TCreateProductFieldValues>
+          id="price"
+          label="Price"
+          type="number"
+          disabled={isLoading}
+          register={register}
+          errors={errors}
+          icon={BiMoney}
+          required
+        />
+
+        <InputField<TCreateProductFieldValues>
+          id="description"
+          label="Description"
+          type="text"
+          disabled={isLoading}
+          register={register}
+          errors={errors}
+          icon={BiPaperPlane}
+          required
+        />
+
+        <InputField<TCreateProductFieldValues>
+          id="category"
+          label="Category"
+          type="text"
+          disabled={isLoading}
+          register={register}
+          errors={errors}
+          icon={BiPackage}
+          required
+        />
+      </div>
+      <div className="col-span-1">
+        <Button
+          isSubmit
+          disabled={isLoading}
+          colorScheme="btn-secondary"
+          label="Create Product"
+        />
+      </div>
+    </form>
+  );
+}

--- a/src/components/inputs/InputField.stories.tsx
+++ b/src/components/inputs/InputField.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MdEmail } from 'react-icons/md';
+import { InputField } from './InputField';
+
+const meta = {
+  title: 'Components/InputField',
+  component: InputField,
+  tags: ['autodocs'],
+  argTypes: {
+    id: { control: 'text' },
+    label: { control: 'text' },
+    type: { control: 'text' },
+    disabled: { control: 'boolean' },
+    icon: { control: 'text' },
+    required: { control: 'boolean' },
+  },
+} satisfies Meta<typeof InputField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    id: 'email',
+    label: 'Email',
+    type: 'email',
+    disabled: false,
+    icon: MdEmail,
+    required: true,
+  },
+};

--- a/src/components/inputs/InputField.tsx
+++ b/src/components/inputs/InputField.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { IconType } from 'react-icons';
+import {
+  UseFormRegister,
+  FieldErrors,
+  FieldValues,
+  Path,
+} from 'react-hook-form';
+import { mergeClassNames } from '../../lib';
+
+export type TInputFieldProps<T extends FieldValues> = {
+  id: keyof T;
+  label: string;
+
+  register?: UseFormRegister<T>;
+  errors?: FieldErrors<T>;
+
+  type?: string;
+  disabled?: boolean;
+  icon?: IconType;
+  required?: boolean;
+};
+
+/**
+ * InputField
+ * @description A form input field with label and error message
+ * It can be used on any form, so long as the form is using react-hook-form
+ * and the type definitions are inferred from zod schemas. See the Demo.tsx
+ *
+ * @param id The id of the input field
+ * @param label The label of the input field
+ * @param register The register function from react-hook-form
+ * @param errors The errors object from react-hook-form
+ * @param type The type of the input field
+ * @param disabled Whether the input field is disabled
+ * @param icon The icon to be displayed on the left side of the input field
+ * @param required Whether the input field is required
+ *
+ * @returns A form input field with label and error message
+ *
+ * @example
+ * <InputField<TLoginFieldValues>
+ *  id="email"
+ * label="Email"
+ * type="email"
+ * disabled={isLoading}
+ * register={register}
+ * errors={errors}
+ * icon={MdEmail}
+ * required
+ * />
+ *
+ * @example
+ * <InputField<TLoginFieldValues>
+ * id="password"
+ * label="Password"
+ * type="password"
+ * disabled={isLoading}
+ * register={register}
+ * errors={errors}
+ * icon={BsFillLockFill}
+ * required
+ * />
+ */
+export function InputField<T extends FieldValues>({
+  id,
+  label,
+  register,
+  errors,
+
+  type = 'text',
+  disabled = false,
+  icon: Icon,
+  required = false,
+}: TInputFieldProps<T>) {
+  const registerFunction = register?.(id as Path<T>, {
+    required,
+    [type === 'number' ? 'valueAsNumber' : '']: true,
+  });
+
+  const {
+    name, onBlur, onChange, ref,
+  } = registerFunction || {};
+
+  const inputClassNames = mergeClassNames({
+    'absolute w-full border dark:text-white rounded-lg py-4 rounded backdrop-blur-md bg-cyan-400/5':
+      true,
+    'pl-10': !!Icon,
+    'pl-2': !Icon,
+    'pr-3 outline-cyan-100 peer focus:ring-0': true,
+    'border-red-300 outline-red-300': !!errors?.[id],
+    'border-cyan-300 outline-cyan-300': !errors?.[id],
+  });
+
+  const labelClassNames = mergeClassNames({
+    '&:not(peer-placeholder-shown)]:translate-x-2 peer-placeholder-shown:translate-y-3  [&:not(peer-placeholder-shown)]:-translate-y-1/2 peer-focus:-translate-y-4 peer-focus:text-sm peer-focus:translate-x-2 peer-placeholder-shown:translate-x-1 px-2 text-black dark:text-white transition absolute backdrop-blur-md mt-1':
+      true,
+    'ml-10': !!Icon,
+    'text-red-400': !!errors?.[id],
+  });
+
+  const statusTextClassNames = mergeClassNames({
+    'mt-5': true,
+    'text-red-400 outline-red-400': !!errors?.[id],
+    'text-cyan-400 outline-cyan-400': !errors?.[id],
+  });
+
+  return (
+    <div className="flex flex-col gap-2 my-8">
+      <div className="relative h-10">
+        {Icon && (
+          <div className="absolute left-0 z-20 ml-2 -translate-y-1/2 top-7">
+            <Icon size={20} className="dark:text-cyan-400" />
+          </div>
+        )}
+
+        <input
+          id={id as string}
+          disabled={disabled}
+          placeholder=" "
+          type={type}
+          className={inputClassNames}
+          onChange={onChange}
+          onBlur={onBlur}
+          name={name}
+          ref={ref}
+        />
+        <label htmlFor={id as string} className={labelClassNames}>
+          {label}
+        </label>
+      </div>
+      {errors?.[id] && (
+        <span className={statusTextClassNames}>
+          {errors[id]?.message?.toString()}
+        </span>
+      )}
+    </div>
+  );
+}
+
+InputField.defaultProps = {
+  type: 'text',
+  disabled: false,
+  icon: undefined,
+  required: false,
+  register: undefined,
+  errors: undefined,
+};

--- a/src/components/shared/Button.tsx
+++ b/src/components/shared/Button.tsx
@@ -9,6 +9,7 @@ import { ButtonProps } from '../../utils/types';
  * @param {string} variant - Button variant
  * @param {function} onClick - Button click handler
  * @param {boolean} disabled - Button disabled state
+ * @param {boolean} isSubmit - Button type
  * @returns {JSX.Element}
  * @example
  * <Button
@@ -20,6 +21,7 @@ import { ButtonProps } from '../../utils/types';
  * <Button
  * onClick={() => {}}
  * label="Disabled"
+ * isSubmit
  * colorScheme="disabled"
  * />
  */
@@ -27,6 +29,7 @@ import { ButtonProps } from '../../utils/types';
 export function Button({
   label,
   onClick,
+  isSubmit = false,
   colorScheme,
   disabled,
 }: ButtonProps): JSX.Element {
@@ -41,7 +44,7 @@ export function Button({
       className={combinedClassNames}
       onClick={onClick}
       disabled={disabled}
-      type="button"
+      type={isSubmit ? 'submit' : 'button'}
     >
       {label}
     </button>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -5,6 +5,8 @@ import { config } from '../data';
 import { useGoogleAuth } from '../hooks';
 import Alert from '../components/shared/Alert';
 import { checkEnv } from '../utils';
+import { Demo } from '../components/inputs/Demo';
+import { Demo2 } from '../components/inputs/Demo2';
 
 declare global {
   interface Window {
@@ -44,6 +46,8 @@ export function Login() {
       <h1>Login</h1>
       <p>Awesome 🎉! You just reached the login page.</p>
       <p>{baseUrl}</p>
+      <Demo />
+      <Demo2 />
       <p>Now try to navigate to the home page.</p>
       <LinkFacade to="/">Home</LinkFacade>
       <main className="flex__center">

--- a/src/utils/schemas/index.ts
+++ b/src/utils/schemas/index.ts
@@ -1,0 +1,2 @@
+export * from './login.schema';
+export * from './product.schema';

--- a/src/utils/schemas/login.schema.ts
+++ b/src/utils/schemas/login.schema.ts
@@ -1,0 +1,17 @@
+import * as z from 'zod';
+
+export const loginSchema = z.object({
+  email: z
+    .string({
+      required_error: 'Email cannot be empty',
+      invalid_type_error: 'Email must be a string',
+    })
+    .email({
+      message: 'Please enter a valid email address',
+    }),
+  password: z.string().min(6, {
+    message: 'Password must be at least 6 characters',
+  }),
+});
+
+export type TLoginFieldValues = z.infer<typeof loginSchema>;

--- a/src/utils/schemas/product.schema.ts
+++ b/src/utils/schemas/product.schema.ts
@@ -1,0 +1,15 @@
+import * as z from 'zod';
+
+export const createProductSchema = z.object({
+  name: z.string().min(3),
+  price: z
+    .number({
+      required_error: 'Price cannot be empty',
+      invalid_type_error: 'Price must be a number',
+    })
+    .min(1),
+  description: z.string().min(10),
+  category: z.string().min(3),
+});
+
+export type TCreateProductFieldValues = z.infer<typeof createProductSchema>;

--- a/src/utils/types/button.types.ts
+++ b/src/utils/types/button.types.ts
@@ -1,6 +1,7 @@
 export type ButtonProps = {
   label: string;
-  onClick: () => void;
+  onClick?: () => void;
+  isSubmit?: boolean;
   colorScheme:
     | 'btn-primary'
     | 'btn-primary-outline'


### PR DESCRIPTION
# Description

This P.R delivers the component of a re-usable input field. To achieve this, it introduces `zod`, `react-hook-form` and the zod resolver for react-hook-form in order to achieve maximum type-safety across forms and a clear schema definition for validation.

[Loom](https://www.loom.com/share/c118388d65ef4e1faecb89fe40352576)

Fixes #36 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have created a loom video for the new feature or enhancement
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
