### PR TITLE
ft: add parent/generic modal component 📻

### DIFF
--- a/src/assets/styles/components/_button.scss
+++ b/src/assets/styles/components/_button.scss
@@ -1,6 +1,6 @@
 @layer components {
   .btn {
-    @apply px-4 py-2 rounded border-[0.5px] border-white text-white bg-gray-500 shadow hover:shadow-lg transition-all duration-300 ease-in-out backdrop-blur-sm hover:backdrop-blur-md text-center hover:-translate-y-1;
+    @apply w-full px-4 py-2 rounded border-[0.5px] border-white text-white bg-gray-500 shadow hover:shadow-lg transition-all duration-300 ease-in-out backdrop-blur-sm hover:backdrop-blur-md text-center hover:-translate-y-1;
   }
 
   .btn-primary {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,5 +4,16 @@ import { Container } from './Container';
 import { ProductCard } from './products/ProductCard';
 import { Counter } from './inputs/Counter';
 import { Sidebar } from './sidebar/SideBar';
+import { Modal } from './shared/modals/Modal';
+import { Heading } from './Heading';
 
-export { Footer, Navbar, Sidebar, Container, ProductCard, Counter };
+export {
+  Footer,
+  Navbar,
+  Container,
+  ProductCard,
+  Counter,
+  Modal,
+  Heading,
+  Sidebar,
+};

--- a/src/components/shared/Modal.tsx
+++ b/src/components/shared/Modal.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export function Modal() {
-  return <div>Modal</div>;
-}

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -2,7 +2,7 @@ export * from './Button';
 export * from './ButtonGroup';
 export * from './Card';
 export * from './DropDown';
-export * from './Modal';
+export * from './modals/Modal';
 export * from './Stars';
 export * from './CartSummaryCard';
 export * from './SoldByCard';

--- a/src/components/shared/modals/Modal.stories.tsx
+++ b/src/components/shared/modals/Modal.stories.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Modal } from './Modal';
+import { Heading } from '../../Heading';
+
+const meta = {
+  title: 'Components/Modal',
+  component: Modal,
+  argTypes: {
+    title: { control: 'text' },
+    onClose: { action: 'closed' },
+    onSubmit: { action: 'submitted' },
+    actionLabel: { control: 'text' },
+    secondaryActionLabel: { control: 'text' },
+    secondaryAction: { action: 'secondary action' },
+    isOpen: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+  },
+} satisfies Meta<typeof Modal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'Modal Title',
+    body: (
+      <section className="flex flex-col gap-4">
+        <Heading
+          title="Heading: Do something"
+          subtitle="Sub-Heading: Do something else"
+        />
+      </section>
+    ),
+    footer: <div>Modal Footer</div>,
+    actionLabel: 'Primary Action',
+    isOpen: true,
+    onClose: () => {
+      // do something
+    },
+    onSubmit: () => {
+      // do something
+    },
+  },
+};
+
+export const WithSecondaryAction: Story = {
+  args: {
+    title: 'Modal Title',
+    body: (
+      <section className="flex flex-col gap-4">
+        <Heading
+          title="Heading: We are all centered"
+          subtitle="Sub-Heading: Do something else"
+          center
+        />
+      </section>
+    ),
+    footer: <div>Modal Footer</div>,
+    actionLabel: 'Primary Action',
+    secondaryActionLabel: 'Secondary Action',
+    secondaryAction: () => {
+      // do something
+    },
+    isOpen: true,
+    onClose: () => {
+      // do something
+    },
+    onSubmit: () => {
+      // do something
+    },
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    title: 'Modal Title',
+    body: <div>Modal Body</div>,
+    footer: <div>Modal Footer</div>,
+    actionLabel: 'Primary Action',
+    secondaryActionLabel: 'Secondary Action',
+    secondaryAction: () => {
+      // do something
+    },
+    isOpen: true,
+    onClose: () => {
+      // do something
+    },
+    onSubmit: () => {
+      // do something
+    },
+    disabled: true,
+  },
+};

--- a/src/components/shared/modals/Modal.tsx
+++ b/src/components/shared/modals/Modal.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { ModalLogicParams, useModalLogic } from '../../../hooks';
+import { ModalHeader } from './ModalHeader';
+import { ModalFooter } from './ModalFooter';
+import { mergeClassNames } from '../../../lib';
+
+type ModalProps = {
+  onClose: () => void;
+  onSubmit: () => void;
+  actionLabel: string;
+  isOpen?: boolean;
+  title?: string;
+  body?: React.ReactElement;
+  footer?: React.ReactElement;
+  disabled?: boolean;
+  secondaryAction?: () => void;
+  secondaryActionLabel?: string;
+};
+
+export function Modal({
+  isOpen,
+  onClose,
+  onSubmit,
+  title,
+  body,
+  footer,
+  actionLabel,
+  disabled,
+  secondaryAction,
+  secondaryActionLabel,
+}: ModalProps) {
+  const ModalLogicArgs: ModalLogicParams = {
+    onClose,
+    onSubmit,
+    secondaryAction,
+    isOpen,
+    disabled,
+  };
+
+  const {
+    modalRef,
+    buttonRef,
+    handleClose,
+    handleSecondaryAction,
+    handleSubmit,
+    showModal,
+  } = useModalLogic(ModalLogicArgs);
+
+  const modalRefClassNames = mergeClassNames({
+    'duration-300': true,
+    'translate-y-0 opacity-100': showModal,
+    'translate-y-full opacity-0': !showModal,
+  });
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-x-hidden overflow-y-auto outline-none focus:outline-none bg-neutral-800/70">
+      <div className="relative w-full h-full mx-auto my-6 md:w-4/6 lg:w-3/6 xl:w-2/5 lg:h-auto md:h-auto">
+        <div ref={modalRef} className={modalRefClassNames}>
+          <div className="relative flex flex-col w-full h-full bg-white border-0 rounded-md shadow-lg outline-none dark:bg-dark dark:text-white lg:h-auto md:h-auto focus:outline-none">
+            <ModalHeader
+              title={title}
+              buttonRef={buttonRef}
+              handleClose={handleClose}
+            />
+
+            <main className="relative flex-auto p-6">{body}</main>
+
+            <ModalFooter
+              actionLabel={actionLabel}
+              disabled={disabled}
+              footer={footer}
+              handleSecondaryAction={handleSecondaryAction}
+              handleSubmit={handleSubmit}
+              secondaryAction={secondaryAction}
+              secondaryActionLabel={secondaryActionLabel}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Modal.defaultProps = {
+  isOpen: false,
+  title: '',
+  body: <div>Body</div>,
+  footer: <div>Footer</div>,
+  disabled: false,
+  secondaryAction: () => {
+    // do something
+  },
+  secondaryActionLabel: '',
+};

--- a/src/components/shared/modals/ModalFooter.tsx
+++ b/src/components/shared/modals/ModalFooter.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Button } from '../Button';
+
+type ModalFooterProps = {
+  actionLabel: string;
+  disabled?: boolean;
+  footer?: React.ReactElement;
+  handleSecondaryAction: () => void;
+  handleSubmit: () => void;
+  secondaryAction?: () => void;
+  secondaryActionLabel?: string;
+};
+export function ModalFooter({
+  actionLabel,
+  handleSecondaryAction,
+  handleSubmit,
+  disabled,
+  footer,
+  secondaryAction,
+  secondaryActionLabel,
+}: ModalFooterProps) {
+  return (
+    <footer className="flex flex-col gap-2 p-6">
+      <div className="flex flex-col items-center w-full gap-4 sm:flex-row ">
+        {secondaryAction && secondaryActionLabel && (
+          <Button
+            disabled={disabled}
+            label={secondaryActionLabel}
+            onClick={handleSecondaryAction}
+            colorScheme="btn-secondary-outline"
+          />
+        )}
+        <Button
+          disabled={disabled}
+          label={actionLabel}
+          onClick={handleSubmit}
+          colorScheme="btn-secondary"
+        />
+      </div>
+      {footer}
+    </footer>
+  );
+}
+
+ModalFooter.defaultProps = {
+  disabled: false,
+  secondaryAction: undefined,
+  secondaryActionLabel: undefined,
+  footer: undefined,
+};

--- a/src/components/shared/modals/ModalHeader.tsx
+++ b/src/components/shared/modals/ModalHeader.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { IoMdClose } from 'react-icons/io';
+
+type ModalHeaderProps = {
+  title?: string;
+  handleClose: () => void;
+  buttonRef: React.RefObject<HTMLButtonElement>;
+};
+
+export function ModalHeader({
+  title,
+  handleClose,
+  buttonRef,
+}: ModalHeaderProps) {
+  return (
+    <header className="relative flex items-center justify-center p-6 border-b rounded-t">
+      <button
+        type="button"
+        ref={buttonRef}
+        onClick={handleClose}
+        className="absolute p-1 transition border-0 hover:opacity-70 left-9"
+      >
+        <IoMdClose size={18} />
+      </button>
+      <h2 className="text-lg font-semibold">{title}</h2>
+    </header>
+  );
+}
+
+ModalHeader.defaultProps = {
+  title: '',
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './useTheme';
 export * from './useSideBar';
 export * from './useHomeLogic';
 export * from './useSideBar';
+export * from './useModal';

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,82 @@
+import {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
+
+export type ModalLogicParams = {
+  onClose: () => void;
+  onSubmit: () => void;
+  secondaryAction?: () => void;
+  isOpen?: boolean;
+  disabled?: boolean;
+};
+export const useModalLogic = ({
+  onClose,
+  onSubmit,
+  secondaryAction,
+  isOpen = false,
+  disabled = false,
+}: ModalLogicParams) => {
+  const [showModal, setShowModal] = useState(isOpen);
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setShowModal(isOpen);
+  }, [isOpen]);
+
+  const handleClose = useCallback(() => {
+    if (disabled) return;
+    setShowModal(false);
+    setTimeout(() => {
+      onClose();
+    }, 300);
+  }, [disabled, onClose]);
+
+  useEffect(() => {
+    setShowModal(isOpen);
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        buttonRef.current
+        && modalRef.current
+        && !buttonRef.current.contains(e.target as Node)
+        && !modalRef.current.contains(e.target as Node)
+      ) {
+        handleClose();
+      }
+    };
+
+    const handleCloseModal = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        handleClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleCloseModal);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleCloseModal);
+    };
+  }, [isOpen, handleClose]);
+
+  const handleSubmit = useCallback(() => {
+    if (disabled) return;
+    onSubmit();
+  }, [disabled, onSubmit]);
+
+  const handleSecondaryAction = useCallback(() => {
+    if (disabled || !secondaryAction) return;
+    secondaryAction();
+  }, [disabled, secondaryAction]);
+
+  return {
+    showModal,
+    buttonRef,
+    modalRef,
+    handleClose,
+    handleSubmit,
+    handleSecondaryAction,
+  };
+};


### PR DESCRIPTION
# Description

This P.R deliver a parent modal component.

The `<Modal/>` component can take different props, including, but not limited to, a `header, body, footer` all which are html elements, and different actions and states to control visibility.

[Loom](https://www.loom.com/share/3780c9b0c02c4a99961d814ceb9ff710)

Fixes #53 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have created a loom video for the new feature or enhancement
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
